### PR TITLE
feat: add button to draw "Hello Uber" text on canvas

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -49,7 +49,7 @@ import {
 } from "@excalidraw/excalidraw/components/icons";
 import { isElementLink } from "@excalidraw/element";
 import { restore, restoreAppState } from "@excalidraw/excalidraw/data/restore";
-import { newElementWith } from "@excalidraw/element";
+import { newElementWith, newTextElement } from "@excalidraw/element";
 import { isInitializedImageElement } from "@excalidraw/element";
 import clsx from "clsx";
 import {
@@ -849,18 +849,54 @@ const ExcalidrawWrapper = () => {
         autoFocus={true}
         theme={editorTheme}
         renderTopRightUI={(isMobile) => {
-          if (isMobile || !collabAPI || isCollabDisabled) {
-            return null;
-          }
           return (
-            <div className="top-right-ui">
-              {collabError.message && <CollabError collabError={collabError} />}
-              <LiveCollaborationTrigger
-                isCollaborating={isCollaborating}
-                onSelect={() =>
-                  setShareDialogState({ isOpen: true, type: "share" })
-                }
-              />
+            <div
+              className="top-right-ui"
+              style={{ display: "flex", gap: "8px", alignItems: "center" }}
+            >
+              <button
+                style={{
+                  padding: "8px 16px",
+                  backgroundColor: "#6965db",
+                  color: "white",
+                  border: "none",
+                  borderRadius: "8px",
+                  cursor: "pointer",
+                  fontWeight: "bold",
+                  fontSize: "14px",
+                }}
+                onClick={() => {
+                  if (excalidrawAPI) {
+                    const textElement = newTextElement({
+                      x: 100,
+                      y: 100,
+                      text: "Hello Uber",
+                      fontSize: 36,
+                      strokeColor: "#000000",
+                    });
+
+                    const currentElements = excalidrawAPI.getSceneElements();
+                    excalidrawAPI.updateScene({
+                      elements: [...currentElements, textElement],
+                    });
+                  }
+                }}
+              >
+                Draw "Hello Uber"
+              </button>
+              {!isMobile && collabAPI && !isCollabDisabled && (
+                <>
+                  {collabError.message && (
+                    <CollabError collabError={collabError} />
+                  )}
+                  <LiveCollaborationTrigger
+                    isCollaborating={isCollaborating}
+                    onSelect={() =>
+                      setShareDialogState({ isOpen: true, type: "share" })
+                    }
+                  />
+                </>
+              )}
             </div>
           );
         }}


### PR DESCRIPTION
## Summary
- Added a custom button in the top-right UI that draws "Hello Uber" text on the canvas
- The button uses the Excalidraw API to programmatically create and add text elements
- Text appears at position (100, 100) with 36px font size

## Test plan
1. Start the dev server with `yarn start`
2. Open http://localhost:3000/
3. Click the purple "Draw Hello Uber" button in the top-right corner
4. Verify that "Hello Uber" text appears on the canvas
5. Click multiple times to add multiple text elements

🤖 Generated with [Claude Code](https://claude.ai/code)